### PR TITLE
runroot method filter in webui

### DIFF
--- a/roles/koji_hub/templates/web.conf.j2
+++ b/roles/koji_hub/templates/web.conf.j2
@@ -35,3 +35,5 @@ LibPath = /usr/share/koji-web/lib
 loginDisabled = True
 
 KojiHubCA = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+Tasks = runroot


### PR DESCRIPTION
Koji 1.12 introduced configurable filter in web ui. As result, runroot method (from plugin) is no more visible by default and needs it explicitly listed.

See: https://pagure.io/koji/c/637524471554f4691c0cb543f7991d0722041dce?branch=master